### PR TITLE
Encode double quote when <var> is given --htmlencode option.

### DIFF
--- a/src/main/perl/lib/Bedrock/Text/TagX/TAG/NoBody/Var.pm.in
+++ b/src/main/perl/lib/Bedrock/Text/TagX/TAG/NoBody/Var.pm.in
@@ -825,6 +825,7 @@ sub finalize {
     $value =~ s/\x26/&amp;/g;
     $value =~ s/\x3c/&lt;/g;
     $value =~ s/\x3e/&gt;/g;
+    $value =~ s/\x22/&quot;/g;
     &log_message( $self, "HTMLEncoded to <$value>" ) if $verbose;
   } elsif ( exists $options{'urlencode'} and $options{'urlencode'} > 0 ) {
     &Text::URLEncode::encode($value);


### PR DESCRIPTION
Use case: ability to include strings with double quotes in text form fields:

  <input name=q type=text value="<var --htmlencode $input.q>">
