### PR TITLE
Removed unnecessary localization of $_

### DIFF
--- a/src/main/perl/lib/Bedrock/Text/TagX.pm.in
+++ b/src/main/perl/lib/Bedrock/Text/TagX.pm.in
@@ -102,7 +102,6 @@ sub parse {
   my $line = 0;
   my $file = $self->{'error'}->file;
 
-  local ($_);
   my $raw;
 
   INPUT:


### PR DESCRIPTION
I cannot figure out the purpose of this in the code, seems superfluous.  I think it is a good idea to remove it because it makes one scratch his head needlessly.
